### PR TITLE
support md in annotation

### DIFF
--- a/examples/web/components/Playground.tsx
+++ b/examples/web/components/Playground.tsx
@@ -21,8 +21,8 @@ in a different context.
 \`\`\`js annotate
 const blog = "https://jser.dev"
 //                    ^
-//       [JSer.dev is the homepage for JSer.]
-//       [Check it out!]
+//       [JSer.dev is the *homepage* for JSer.]
+//       [Check it out! [jser.dev](https://jser.dev)]
 // This is a normal comment
 \`\`\`
 
@@ -34,8 +34,8 @@ See how the callout is rendered separately from normal comments
 // This is normal comments from source code.
 const blog = "https://jser.dev"
 //                    ~~~~~~~~
-//       [JSer.dev is the homepage for JSer.]
-//       [Check it out!]
+//       [JSer.dev is the **homepage** for JSer.]
+//       [Check it out! [jser.dev](https://jser.dev)]
 
 const blog = "jser.dev"
 //            --------

--- a/examples/web/global.css
+++ b/examples/web/global.css
@@ -24,7 +24,14 @@ pre.shiki .line.dim {
   margin: 0.5em 0;
   display: inline-block;
   border-radius: 3px;
+}
 
+.shaku-callout p {
+  margin: 0;
+}
+
+.shaku-callout a {
+  color: #fff;
 }
 
 .shaku-callout-arrow {
@@ -46,6 +53,13 @@ pre.shiki .line.dim {
   margin: 0.3em 0;
 }
 
+.shaku-underline p {
+  margin: 0;
+}
+
+.shaku-underline a {
+  color: red;
+}
 .shaku-underline-line {
   line-height: 0;
   top: 0.5em;
@@ -58,15 +72,15 @@ pre.shiki .line.dim {
   text-decoration-thickness: 2px;
 }
 
-.shaku-underline-wavy>.shaku-underline-line {
+.shaku-underline-wavy > .shaku-underline-line {
   text-decoration-style: wavy;
   top: 0.7em;
 }
 
-.shaku-underline-solid>.shaku-underline-line {
+.shaku-underline-solid > .shaku-underline-line {
   text-decoration-style: solid;
 }
 
-.shaku-underline-dotted>.shaku-underline-line {
+.shaku-underline-dotted > .shaku-underline-line {
   text-decoration-style: dotted;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,8 +90,8 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
         "remark-shaku-code-annotate": "*",
-        "shiki": "^0.14.2",
-        "ui": "*"
+        "shaku-ui": "*",
+        "shiki": "^0.14.2"
       },
       "devDependencies": {
         "@types/node": "^17.0.12",
@@ -1775,6 +1775,15 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.9.0.tgz",
+      "integrity": "sha512-4fP/kEcKNj2u39IzrxWYuf/FnCCwwQCpif6wwY6ROUS1EPRIfWJjGkY3HIowY1EX/VbX5e86yq8AAE7UPMgATg==",
+      "dev": true,
+      "dependencies": {
+        "htmlparser2": "^8.0.0"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
@@ -3081,6 +3090,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -3161,6 +3178,57 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.397",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.397.tgz",
@@ -3193,6 +3261,17 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -4714,6 +4793,24 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/human-id": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/human-id/-/human-id-1.0.2.tgz",
@@ -5081,6 +5178,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-reference": {
@@ -6971,6 +7076,11 @@
       "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -7508,6 +7618,20 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/rehype-stringify": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
+      "integrity": "sha512-kWiZ1bgyWlgOxpqD5HnxShKAdXtb2IUljn3hQAhySeak6IOQPPt6DeGnsIh4ixm7yKJWzm8TXFuC/lPfcWHJqw==",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "hast-util-to-html": "^8.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
@@ -7553,9 +7677,9 @@
       }
     },
     "node_modules/remark-parse": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
-      "integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
@@ -7752,6 +7876,19 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/sanitize-html": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.10.0.tgz",
+      "integrity": "sha512-JqdovUd81dG4k87vZt6uA6YhDfWkUGruUu/aPmXLxXi45gZExnt9Bnw/qeQU8oGf82vPyaE0vO4aH0PbobB9JQ==",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -9000,10 +9137,6 @@
       "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
       "dev": true
     },
-    "node_modules/ui": {
-      "resolved": "packages/ui",
-      "link": true
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -9252,9 +9385,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.3.tgz",
-      "integrity": "sha512-MwFlLBO4udZXd+VBcezo3u8mC77YQk+ik+fbc0GZWGgzfbPP+8Kf0fldhARqvSYmtIWoAJ5BXPClUbMTlqFxrA==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.17.5",
@@ -9843,8 +9976,11 @@
       "license": "MIT",
       "dependencies": {
         "mdast": "^3.0.0",
+        "rehype-stringify": "^9.0.3",
         "remark": "^14.0.2",
         "remark-html": "^15.0.2",
+        "remark-parse": "^10.0.2",
+        "remark-rehype": "^10.1.0",
         "shaku-code-annotate": "*",
         "shiki": "^0.14.2",
         "unified": "^10.1.2",
@@ -9863,11 +9999,13 @@
         "mdast": "^3.0.0",
         "remark": "^14.0.2",
         "remark-html": "^15.0.2",
+        "sanitize-html": "^2.10.0",
         "shiki": "^0.14.2",
         "unified": "^10.1.2",
         "unist-util-visit": "^4.1.2"
       },
       "devDependencies": {
+        "@types/sanitize-html": "^2.9.0",
         "tsup": "^6.7.0",
         "typescript": "latest",
         "vitest": "^0.30.1"
@@ -9891,6 +10029,7 @@
     },
     "packages/ui": {
       "version": "0.0.0",
+      "extraneous": true,
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -9900,19 +10039,6 @@
         "react": "^17.0.2",
         "tsconfig": "*",
         "typescript": "^4.5.2"
-      }
-    },
-    "packages/ui/node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     }
   },
@@ -11129,6 +11255,15 @@
         "@types/react": "*"
       }
     },
+    "@types/sanitize-html": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.9.0.tgz",
+      "integrity": "sha512-4fP/kEcKNj2u39IzrxWYuf/FnCCwwQCpif6wwY6ROUS1EPRIfWJjGkY3HIowY1EX/VbX5e86yq8AAE7UPMgATg==",
+      "dev": true,
+      "requires": {
+        "htmlparser2": "^8.0.0"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.3",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
@@ -12089,6 +12224,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="
     },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+    },
     "defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -12142,6 +12282,39 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "requires": {
+        "domelementtype": "^2.3.0"
+      }
+    },
+    "domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "requires": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.397",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.397.tgz",
@@ -12169,6 +12342,11 @@
       "requires": {
         "ansi-colors": "^4.1.1"
       }
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -13312,6 +13490,17 @@
       "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-2.0.1.tgz",
       "integrity": "sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A=="
     },
+    "htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "requires": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "human-id": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/human-id/-/human-id-1.0.2.tgz",
@@ -13542,6 +13731,11 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+    },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-reference": {
       "version": "3.0.1",
@@ -14810,6 +15004,11 @@
       "resolved": "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz",
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -15168,6 +15367,16 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
     },
+    "rehype-stringify": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-9.0.3.tgz",
+      "integrity": "sha512-kWiZ1bgyWlgOxpqD5HnxShKAdXtb2IUljn3hQAhySeak6IOQPPt6DeGnsIh4ixm7yKJWzm8TXFuC/lPfcWHJqw==",
+      "requires": {
+        "@types/hast": "^2.0.0",
+        "hast-util-to-html": "^8.0.0",
+        "unified": "^10.0.0"
+      }
+    },
     "remark": {
       "version": "14.0.2",
       "resolved": "https://registry.npmjs.org/remark/-/remark-14.0.2.tgz",
@@ -15201,9 +15410,9 @@
       }
     },
     "remark-parse": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
-      "integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
+      "integrity": "sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-from-markdown": "^1.0.0",
@@ -15225,8 +15434,11 @@
       "version": "file:packages/remark-shaku-code-annotate",
       "requires": {
         "mdast": "^3.0.0",
+        "rehype-stringify": "^9.0.3",
         "remark": "^14.0.2",
         "remark-html": "^15.0.2",
+        "remark-parse": "^10.0.2",
+        "remark-rehype": "^10.1.0",
         "shaku-code-annotate": "*",
         "shiki": "^0.14.2",
         "tsup": "^6.7.0",
@@ -15334,6 +15546,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "sanitize-html": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.10.0.tgz",
+      "integrity": "sha512-JqdovUd81dG4k87vZt6uA6YhDfWkUGruUu/aPmXLxXi45gZExnt9Bnw/qeQU8oGf82vPyaE0vO4aH0PbobB9JQ==",
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
     "scheduler": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
@@ -15403,9 +15628,11 @@
     "shaku-code-annotate": {
       "version": "file:packages/shaku-code-annotate",
       "requires": {
+        "@types/sanitize-html": "*",
         "mdast": "^3.0.0",
         "remark": "^14.0.2",
         "remark-html": "^15.0.2",
+        "sanitize-html": "^2.10.0",
         "shiki": "^0.14.2",
         "tsup": "^6.7.0",
         "typescript": "latest",
@@ -16258,30 +16485,6 @@
       "integrity": "sha512-MvlCc4GHrmZdAllBc0iUDowff36Q9Ndw/UzqmEKyrfSzokTd9ZCy1i+IIk5hrYKkjoYVQyNbrw7/F8XJ2rEwTg==",
       "dev": true
     },
-    "ui": {
-      "version": "file:packages/ui",
-      "requires": {
-        "@types/react": "^18.2.0",
-        "@types/react-dom": "^18.2.0",
-        "eslint": "^7.32.0",
-        "eslint-config-custom": "*",
-        "react": "^17.0.2",
-        "tsconfig": "*",
-        "typescript": "^4.5.2"
-      },
-      "dependencies": {
-        "react": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
-      }
-    },
     "unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -16450,9 +16653,9 @@
       }
     },
     "vite": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.3.tgz",
-      "integrity": "sha512-MwFlLBO4udZXd+VBcezo3u8mC77YQk+ik+fbc0GZWGgzfbPP+8Kf0fldhARqvSYmtIWoAJ5BXPClUbMTlqFxrA==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.3.9.tgz",
+      "integrity": "sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==",
       "dev": true,
       "requires": {
         "esbuild": "^0.17.5",
@@ -16566,7 +16769,7 @@
         "@monaco-editor/react": "^4.5.1",
         "@next/mdx": "^13.4.4",
         "@stefanprobst/remark-shiki": "^2.2.1",
-        "@types/mdx": "*",
+        "@types/mdx": "^2.0.5",
         "@types/node": "^17.0.12",
         "@types/react": "^18.0.22",
         "@types/react-dom": "^18.0.7",
@@ -16577,10 +16780,10 @@
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
         "remark-shaku-code-annotate": "*",
+        "shaku-ui": "*",
         "shiki": "^0.14.2",
         "tsconfig": "*",
-        "typescript": "^4.5.3",
-        "ui": "*"
+        "typescript": "^4.5.3"
       }
     },
     "web-namespaces": {

--- a/packages/remark-shaku-code-annotate/README.md
+++ b/packages/remark-shaku-code-annotate/README.md
@@ -118,6 +118,10 @@ pre.shiki .line.dim {
   border-radius: 3px;
 }
 
+.shaku-callout p {
+  margin: 0;
+}
+
 .shaku-callout-arrow {
   width: 1ch;
   height: 1ch;

--- a/packages/remark-shaku-code-annotate/README.md
+++ b/packages/remark-shaku-code-annotate/README.md
@@ -21,8 +21,8 @@ export default async function Page() {
 
 const blog = "https://jser.dev"
 //                    ^
-//       [JSer.dev is the homepage for JSer.]
-//       [Check it out!]
+//       [JSer.dev is the **homepage** for JSer.]
+//       [Check it out! [jser.dev](https://jser.dev)]
 
 const blog = "https://jser.dev"
 //                    ~~~~~~~~
@@ -122,6 +122,10 @@ pre.shiki .line.dim {
   margin: 0;
 }
 
+.shaku-callout a {
+  color: #fff;
+}
+
 .shaku-callout-arrow {
   width: 1ch;
   height: 1ch;
@@ -141,6 +145,13 @@ pre.shiki .line.dim {
   margin: 0.3em 0;
 }
 
+.shaku-underline p {
+  margin: 0;
+}
+
+.shaku-underline a {
+  color: red;
+}
 .shaku-underline-line {
   line-height: 0;
   top: 0.5em;

--- a/packages/remark-shaku-code-annotate/package.json
+++ b/packages/remark-shaku-code-annotate/package.json
@@ -3,8 +3,11 @@
   "version": "0.0.7",
   "dependencies": {
     "mdast": "^3.0.0",
+    "rehype-stringify": "^9.0.3",
     "remark": "^14.0.2",
     "remark-html": "^15.0.2",
+    "remark-parse": "^10.0.2",
+    "remark-rehype": "^10.1.0",
     "shaku-code-annotate": "*",
     "shiki": "^0.14.2",
     "unified": "^10.1.2",

--- a/packages/remark-shaku-code-annotate/src/__tests__/index.test.ts
+++ b/packages/remark-shaku-code-annotate/src/__tests__/index.test.ts
@@ -58,8 +58,7 @@ const a = 1;
    /* [This is line two] */
 \`\`\`
 `);
-  const expected = `<pre class="shiki" style="color:#24292e;background-color:#fff"><div class="code-container"><code><div class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #005CC5">1</span><span style="color: #24292E">;</span></div><div class="shaku-callout" style="left:6ch"><span class="shaku-callout-arrow" style="left:0ch"></span>This is line 1
-This is line two</div></code></div></pre>
+  const expected = `<pre class="shiki" style="color:#24292e;background-color:#fff"><div class="code-container"><code><div class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #005CC5">1</span><span style="color: #24292E">;</span></div><div class="shaku-callout" style="left:6ch"><span class="shaku-callout-arrow" style="left:0ch"></span><p>This is line 1</p><p>This is line two</p></div></code></div></pre>
 `;
   expect(result1.value).toEqual(expected);
   expect(result2.value).toEqual(expected);
@@ -83,8 +82,7 @@ const a = 1;
 \`\`\`
 `);
 
-  const expected = `<pre class="shiki" style="color:#24292e;background-color:#fff"><div class="code-container"><code><div class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #005CC5">1</span><span style="color: #24292E">;</span></div><div class="shaku-underline shaku-underline-solid" style="left:6ch"><span class="shaku-underline-line" style="left:0ch">-----</span>This is line 1
-This is line two</div></code></div></pre>
+  const expected = `<pre class="shiki" style="color:#24292e;background-color:#fff"><div class="code-container"><code><div class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #005CC5">1</span><span style="color: #24292E">;</span></div><div class="shaku-underline shaku-underline-solid" style="left:6ch"><span class="shaku-underline-line" style="left:0ch">-----</span><p>This is line 1</p><p>This is line two</p></div></code></div></pre>
 `;
   expect(result1.value).toEqual(expected);
   expect(result2.value).toEqual(expected);
@@ -107,8 +105,7 @@ const a = 1;
       [This is line two] */
 \`\`\`
 `);
-  const expected = `<pre class="shiki" style="color:#24292e;background-color:#fff"><div class="code-container"><code><div class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #005CC5">1</span><span style="color: #24292E">;</span></div><div class="shaku-underline shaku-underline-dotted" style="left:6ch"><span class="shaku-underline-line" style="left:0ch">.....</span>This is line 1
-This is line two</div></code></div></pre>
+  const expected = `<pre class="shiki" style="color:#24292e;background-color:#fff"><div class="code-container"><code><div class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #005CC5">1</span><span style="color: #24292E">;</span></div><div class="shaku-underline shaku-underline-dotted" style="left:6ch"><span class="shaku-underline-line" style="left:0ch">.....</span><p>This is line 1</p><p>This is line two</p></div></code></div></pre>
 `;
   expect(result1.value).toEqual(expected);
   expect(result2.value).toEqual(expected);
@@ -133,8 +130,7 @@ const a = 1;
 \`\`\`
 `);
 
-  const expected = `<pre class="shiki" style="color:#24292e;background-color:#fff"><div class="code-container"><code><div class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #005CC5">1</span><span style="color: #24292E">;</span></div><div class="shaku-underline shaku-underline-wavy" style="left:6ch"><span class="shaku-underline-line" style="left:0ch">~~~~~</span>This is line 1
-This is line two</div></code></div></pre>
+  const expected = `<pre class="shiki" style="color:#24292e;background-color:#fff"><div class="code-container"><code><div class="line"><span style="color: #D73A49">const</span><span style="color: #24292E"> </span><span style="color: #005CC5">a</span><span style="color: #24292E"> </span><span style="color: #D73A49">=</span><span style="color: #24292E"> </span><span style="color: #005CC5">1</span><span style="color: #24292E">;</span></div><div class="shaku-underline shaku-underline-wavy" style="left:6ch"><span class="shaku-underline-line" style="left:0ch">~~~~~</span><p>This is line 1</p><p>This is line two</p></div></code></div></pre>
 `;
   expect(result1.value).toEqual(expected);
   expect(result2.value).toEqual(expected);

--- a/packages/remark-shaku-code-annotate/src/index.ts
+++ b/packages/remark-shaku-code-annotate/src/index.ts
@@ -72,11 +72,6 @@ export const remarkShakuCodeAnnotate = (
                     minOffset,
                     nextLine.line.config.offset + nextLine.offset
                   );
-                  const raw = nextLine.line.config.content;
-                  const processed = String(
-                    unifiedProcessor.processSync(nextLine.line.config.content)
-                  );
-
                   contents.push(
                     String(
                       unifiedProcessor.processSync(nextLine.line.config.content)
@@ -172,13 +167,6 @@ export const remarkShakuCodeAnnotate = (
                     minOffset,
                     nextLine.line.config.offset + nextLine.offset
                   );
-
-                  console.log(
-                    String(
-                      unifiedProcessor.processSync(nextLine.line.config.content)
-                    )
-                  );
-                  console.log("raw", nextLine.line.config.content);
                   contents.push(
                     String(
                       unifiedProcessor.processSync(nextLine.line.config.content)

--- a/packages/shaku-code-annotate/package.json
+++ b/packages/shaku-code-annotate/package.json
@@ -5,11 +5,13 @@
     "mdast": "^3.0.0",
     "remark": "^14.0.2",
     "remark-html": "^15.0.2",
+    "sanitize-html": "^2.10.0",
     "shiki": "^0.14.2",
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.2"
   },
   "devDependencies": {
+    "@types/sanitize-html": "^2.9.0",
     "tsup": "^6.7.0",
     "typescript": "latest",
     "vitest": "^0.30.1"

--- a/packages/shaku-code-annotate/src/__tests__/parse.test.ts
+++ b/packages/shaku-code-annotate/src/__tests__/parse.test.ts
@@ -2,7 +2,7 @@ import { test, describe, expect } from "vitest";
 import { parseLine, shouldApplyAnnotation } from "../index";
 
 describe("parseLine() can parse comment lines", () => {
-  test("  -------  ", async () => {
+  test("  -------  ", () => {
     const result = parseLine("  -------");
     expect(result).toEqual({
       type: "DirectiveUnderline",
@@ -14,7 +14,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("  ~~~~~~~~  ", async () => {
+  test("  ~~~~~~~~  ", () => {
     const result = parseLine("  ~~~~~~~~");
     expect(result).toEqual({
       type: "DirectiveUnderline",
@@ -26,7 +26,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("  ......  ", async () => {
+  test("  ......  ", () => {
     const result = parseLine("  ......");
     expect(result).toEqual({
       type: "DirectiveUnderline",
@@ -38,7 +38,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   [This is annotation]  ", async () => {
+  test("   [This is annotation]  ", () => {
     const result = parseLine("   [This is annotation]");
     expect(result).toEqual({
       type: "AnnotationLine",
@@ -49,18 +49,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   [This is annotation]  ", async () => {
-    const result = parseLine("   [This is annotation]");
-    expect(result).toEqual({
-      type: "AnnotationLine",
-      config: {
-        content: "This is annotation",
-        offset: 3,
-      },
-    });
-  });
-
-  test("   ^  ", async () => {
+  test("   ^  ", () => {
     const result = parseLine("   ^  ");
     expect(result).toEqual({
       type: "DirectiveCallout",
@@ -70,7 +59,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @collapse start ", async () => {
+  test("   @collapse start ", () => {
     const result = parseLine("   @collapse start ");
     expect(result).toEqual({
       type: "DirectiveCollapse",
@@ -81,7 +70,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @collapse end ", async () => {
+  test("   @collapse end ", () => {
     const result = parseLine("   @collapse end ");
     expect(result).toEqual({
       type: "DirectiveCollapse",
@@ -92,11 +81,11 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @collapse unexpected ", async () => {
+  test("   @collapse unexpected ", () => {
     expect(parseLine("   @collapse unexpected ")).toBeNull();
   });
 
-  test("   @highlight start ", async () => {
+  test("   @highlight start ", () => {
     const result = parseLine("   @highlight start ");
     expect(result).toEqual({
       type: "DirectiveHighlight",
@@ -106,7 +95,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @highlight end ", async () => {
+  test("   @highlight end ", () => {
     const result = parseLine("   @highlight end ");
     expect(result).toEqual({
       type: "DirectiveHighlight",
@@ -116,7 +105,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @highlight ", async () => {
+  test("   @highlight ", () => {
     const result = parseLine("   @highlight ");
     expect(result).toEqual({
       type: "DirectiveHighlight",
@@ -126,7 +115,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @highlight below ", async () => {
+  test("   @highlight below ", () => {
     const result = parseLine("   @highlight below ");
     expect(result).toEqual({
       type: "DirectiveHighlight",
@@ -136,10 +125,10 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @highlight unexpected ", async () => {
+  test("   @highlight unexpected ", () => {
     expect(parseLine("   @highlight unexpected ")).toBeNull();
   });
-  test("   @dim start ", async () => {
+  test("   @dim start ", () => {
     const result = parseLine("   @dim start ");
     expect(result).toEqual({
       type: "DirectiveDim",
@@ -149,7 +138,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @dim end ", async () => {
+  test("   @dim end ", () => {
     const result = parseLine("   @dim end ");
     expect(result).toEqual({
       type: "DirectiveDim",
@@ -159,7 +148,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @dim ", async () => {
+  test("   @dim ", () => {
     const result = parseLine("   @dim ");
     expect(result).toEqual({
       type: "DirectiveDim",
@@ -169,7 +158,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @dim below ", async () => {
+  test("   @dim below ", () => {
     const result = parseLine("   @dim below ");
     expect(result).toEqual({
       type: "DirectiveDim",
@@ -179,10 +168,10 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @dim unexpected ", async () => {
+  test("   @dim unexpected ", () => {
     expect(parseLine("   @dim unexpected ")).toBeNull();
   });
-  test("   @focus start ", async () => {
+  test("   @focus start ", () => {
     const result = parseLine("   @focus start ");
     expect(result).toEqual({
       type: "DirectiveFocus",
@@ -192,7 +181,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @focus end ", async () => {
+  test("   @focus end ", () => {
     const result = parseLine("   @focus end ");
     expect(result).toEqual({
       type: "DirectiveFocus",
@@ -202,7 +191,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @focus ", async () => {
+  test("   @focus ", () => {
     const result = parseLine("   @focus ");
     expect(result).toEqual({
       type: "DirectiveFocus",
@@ -212,7 +201,7 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @focus below ", async () => {
+  test("   @focus below ", () => {
     const result = parseLine("   @focus below ");
     expect(result).toEqual({
       type: "DirectiveFocus",
@@ -222,11 +211,11 @@ describe("parseLine() can parse comment lines", () => {
     });
   });
 
-  test("   @focus unexpected ", async () => {
+  test("   @focus unexpected ", () => {
     expect(parseLine("   @focus unexpected ")).toBeNull();
   });
 
-  test("This is some comments from source code ", async () => {
+  test("This is some comments from source code ", () => {
     const result = parseLine("This is some comments from source code");
     expect(result).toBeNull();
   });

--- a/packages/shaku-code-annotate/src/__tests__/render.test.ts
+++ b/packages/shaku-code-annotate/src/__tests__/render.test.ts
@@ -1,0 +1,36 @@
+import { test, describe, expect } from "vitest";
+import { parseLine, renderComponent, shouldApplyAnnotation } from "../index";
+
+describe("renderComponent() can render shaku lines and sanitize html", () => {
+  test("ShakuComponentCallout", () => {
+    const result = renderComponent({
+      type: "ShakuComponentCallout",
+      config: {
+        offset: 5,
+        arrowOffset: 3,
+        contents:
+          '<p><b>This is</b> <em>line</em> <i>1</i> <a href="https://jser.dev">jser.dev</a></p><p><strong>This</strong> <script>alert(3)</script><div>is</div>line 2</p>',
+      },
+    });
+    expect(result).toEqual(
+      '<div class="shaku-callout" style="left:5ch"><span class="shaku-callout-arrow" style="left:3ch"></span><p><b>This is</b> <em>line</em> <i>1</i> <a href="https://jser.dev">jser.dev</a></p><p><strong>This</strong> </p>isline 2<p></p></div>'
+    );
+  });
+
+  test("ShakuComponentCallout", () => {
+    const result = renderComponent({
+      type: "ShakuComponentUnderline",
+      config: {
+        offset: 5,
+        underlineOffset: 3,
+        underlineContent: "-----",
+        underlineStyle: "dotted",
+        contents:
+          '<p><b>This is</b> <em>line</em> <i>1</i> <a href="https://jser.dev">jser.dev</a></p><p><strong>This</strong> <script>alert(3)</script><div>is</div>line 2</p>',
+      },
+    });
+    expect(result).toEqual(
+      '<div class="shaku-underline shaku-underline-dotted" style="left:5ch"><span class="shaku-underline-line" style="left:3ch">-----</span><p><b>This is</b> <em>line</em> <i>1</i> <a href="https://jser.dev">jser.dev</a></p><p><strong>This</strong> </p>isline 2<p></p></div>'
+    );
+  });
+});

--- a/packages/shaku-code-annotate/src/index.ts
+++ b/packages/shaku-code-annotate/src/index.ts
@@ -1,3 +1,5 @@
+import sanitizeHtml from "sanitize-html";
+
 type ShakuDirectiveUnderline = {
   type: "DirectiveUnderline";
   config: {
@@ -233,7 +235,8 @@ type ShakuComponentCallout = {
   config: {
     offset: number;
     arrowOffset: number;
-    contents: string[];
+    /** raw html subt */
+    contents: string;
   };
 };
 
@@ -244,7 +247,8 @@ type ShakuComponentUnderline = {
     underlineOffset: number;
     underlineContent: string;
     underlineStyle: "solid" | "dotted" | "wavy";
-    contents: string[];
+    /** raw html subt */
+    contents: string;
   };
 };
 
@@ -256,9 +260,7 @@ export function renderComponent(component: ShakuComponent) {
         component.config.offset
       }ch"><span class="shaku-callout-arrow" style="left:${
         component.config.arrowOffset
-      }ch"></span>${component.config.contents
-        .map(escapeHtml)
-        .join("\n")}</div>`;
+      }ch"></span>${sanitize(component.config.contents)}</div>`;
     case "ShakuComponentUnderline":
       return `<div class="shaku-underline shaku-underline-${
         component.config.underlineStyle
@@ -266,9 +268,9 @@ export function renderComponent(component: ShakuComponent) {
         component.config.offset
       }ch"><span class="shaku-underline-line" style="left:${
         component.config.underlineOffset
-      }ch">${
-        component.config.underlineContent
-      }</span>${component.config.contents.map(escapeHtml).join("\n")}</div>`;
+      }ch">${component.config.underlineContent}</span>${sanitize(
+        component.config.contents
+      )}</div>`;
     default:
       assertsNever(component);
   }
@@ -278,6 +280,13 @@ function assertsNever(data: never) {
   throw new Error("expected never but got: " + data);
 }
 
-function escapeHtml(html: string) {
-  return html.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+/* only allow restricted html in shaku annotation */
+function sanitize(html: string = "") {
+  const result = sanitizeHtml(html, {
+    allowedTags: ["b", "i", "em", "strong", "a", "p"],
+    allowedAttributes: {
+      a: ["href", "target"],
+    },
+  });
+  return result;
 }

--- a/packages/shaku-code-annotate/src/index.ts
+++ b/packages/shaku-code-annotate/src/index.ts
@@ -235,7 +235,7 @@ type ShakuComponentCallout = {
   config: {
     offset: number;
     arrowOffset: number;
-    /** raw html subt */
+    /** restricted raw html */
     contents: string;
   };
 };
@@ -247,7 +247,7 @@ type ShakuComponentUnderline = {
     underlineOffset: number;
     underlineContent: string;
     underlineStyle: "solid" | "dotted" | "wavy";
-    /** raw html subt */
+    /** restricted raw html */
     contents: string;
   };
 };


### PR DESCRIPTION
close #10 

This PR enables basic markdown support in Shaku annotations.

what you write

```md
const blog = "https://jser.dev"
//                    ^
//       [JSer.dev is the *homepage* for JSer.]
//       [Check it out! [jser.dev](https://jser.dev)]
// This is a normal comment
```

What you get
![Screenshot 2023-06-06 at 14 16 08](https://github.com/JSerZANP/shaku/assets/69352453/cbb3f919-51ac-453f-9095-9c55f486a971)
